### PR TITLE
Handle resource quotas

### DIFF
--- a/.landscaper/blueprint/config/rbac/role.yaml
+++ b/.landscaper/blueprint/config/rbac/role.yaml
@@ -26,6 +26,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - core.gardener.cloud
   resources:
   - shoots

--- a/.landscaper/container/pkg/gardenlogin/operation_delete.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_delete.go
@@ -12,7 +12,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	kErros "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -97,7 +97,7 @@ func (o *operation) deleteApplicationResources(ctx context.Context) error {
 
 func ensureDeleted(ctx context.Context, c client.Client, objectKey client.ObjectKey, obj client.Object) error {
 	if err := c.Get(ctx, objectKey, obj); err != nil {
-		if kErros.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return nil // already deleted
 		}
 

--- a/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
@@ -22,7 +22,7 @@ import (
 	secretsutil "github.com/gardener/gardener/pkg/utils/secrets"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	kErros "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -157,7 +157,7 @@ func (o *operation) loadOrGenerateTLSCertificate(ctx context.Context) (*secretsu
 
 	secret := &corev1.Secret{}
 	if err := rtClient.Get(ctx, client.ObjectKey{Namespace: o.imports.Namespace, Name: o.imports.NamePrefix + TLSSecretSuffix}, secret); err != nil {
-		if !kErros.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 
@@ -224,7 +224,7 @@ func (o *operation) createOrUpdateTLSSecret(ctx context.Context, cert *secretsut
 
 	secret := &corev1.Secret{}
 	if err := rtClient.Get(ctx, objKey, secret); err != nil {
-		if !kErros.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return err
 		}
 

--- a/controllers/shoot_controller_test.go
+++ b/controllers/shoot_controller_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	kErros "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -398,13 +398,13 @@ var _ = Describe("ShootController", func() {
 			By("ensuring shoot is deleted")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &gardencorev1beta1.Shoot{})
-				return kErros.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
 			By("verifying configMap is deleted")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, configMapKey, &corev1.ConfigMap{})
-				return kErros.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 
@@ -424,7 +424,7 @@ var _ = Describe("ShootController", func() {
 				Consistently(func() bool {
 					configMap := &corev1.ConfigMap{}
 					err := k8sClient.Get(ctx, configMapKey, configMap)
-					return kErros.IsNotFound(err)
+					return apierrors.IsNotFound(err)
 				}).Should(BeTrue())
 
 				By("increasing resource quota")
@@ -456,7 +456,7 @@ var _ = Describe("ShootController", func() {
 				isConfigMapNotFound := func() bool {
 					configMap := &corev1.ConfigMap{}
 					if err := k8sClient.Get(ctx, configMapKey, configMap); err != nil {
-						return kErros.IsNotFound(err)
+						return apierrors.IsNotFound(err)
 					}
 
 					return false

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -4,14 +4,13 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 SPDX-License-Identifier: Apache-2.0
 */
 
-package controllers_test
+package controllers
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	"github.com/gardener/gardenlogin-controller-manager/controllers"
 	"github.com/gardener/gardenlogin-controller-manager/internal/test"
 	"github.com/gardener/gardenlogin-controller-manager/internal/util"
 	"github.com/gardener/gardenlogin-controller-manager/webhooks"
@@ -41,10 +40,11 @@ var (
 	k8sManager      ctrl.Manager
 	cmConfig        *util.ControllerManagerConfiguration
 	validator       *webhooks.ConfigmapValidator
-	shootReconciler *controllers.ShootReconciler
+	shootReconciler *ShootReconciler
 )
 
-func TestAPIs(t *testing.T) {
+// TODO rename file to controllers_suite_test.go
+func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	SetDefaultEventuallyTimeout(30 * time.Second)
@@ -68,14 +68,14 @@ var _ = BeforeSuite(func() {
 	k8sManager = environment.K8sManager
 	k8sClient = environment.K8sClient
 
-	shootReconciler = &controllers.ShootReconciler{
+	shootReconciler = &ShootReconciler{
 		Client:                      k8sManager.GetClient(),
 		Log:                         ctrl.Log.WithName("controllers").WithName("Shoot"),
 		Scheme:                      k8sManager.GetScheme(),
 		Config:                      cmConfig,
 		ReconcilerCountPerNamespace: map[string]int{},
 	}
-	err := shootReconciler.SetupWithManager(k8sManager, cmConfig.Controllers.Shoot)
+	err := shootReconciler.SetupWithManager(ctx, k8sManager, cmConfig.Controllers.Shoot)
 	Expect(err).ToNot(HaveOccurred())
 
 	environment.Start()

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
+	k8s.io/apiserver v0.21.2
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	sigs.k8s.io/controller-runtime v0.9.1

--- a/internal/util/quota.go
+++ b/internal/util/quota.go
@@ -1,0 +1,24 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import corev1 "k8s.io/api/core/v1"
+
+// LessThan returns true if a < b for each key in b
+func LessThan(a corev1.ResourceList, b corev1.ResourceList) bool {
+	result := true
+
+	for key, value := range b {
+		if other, found := a[key]; found {
+			if other.Cmp(value) >= 0 {
+				result = false
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/util/quota_test.go
+++ b/internal/util/quota_test.go
@@ -1,0 +1,30 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util_test
+
+import (
+	"github.com/gardener/gardenlogin-controller-manager/internal/util"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var _ = Describe("Quota", func() {
+
+	DescribeTable("x less than y",
+		func(x corev1.ResourceList, y corev1.ResourceList, expected bool) {
+			Expect(util.LessThan(x, y)).To(Equal(expected))
+		},
+		Entry("x > y", corev1.ResourceList{"foo/bar": resource.MustParse("2")}, corev1.ResourceList{"foo/bar": resource.MustParse("1")}, false),
+		Entry("x == y", corev1.ResourceList{"foo/bar": resource.MustParse("1")}, corev1.ResourceList{"foo/bar": resource.MustParse("1")}, false),
+		Entry("x < y", corev1.ResourceList{"foo/bar": resource.MustParse("1")}, corev1.ResourceList{"foo/bar": resource.MustParse("2")}, true),
+		Entry("x has different resource name than y", corev1.ResourceList{"foo/bar": resource.MustParse("1")}, corev1.ResourceList{"bar/baz": resource.MustParse("2")}, true),
+	)
+})

--- a/internal/util/util_suite_test.go
+++ b/internal/util/util_suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -82,13 +83,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx := context.Background()
 	if err = (&controllers.ShootReconciler{
 		Client:                      mgr.GetClient(),
 		Log:                         ctrl.Log.WithName("controllers").WithName("Shoot"),
 		Scheme:                      mgr.GetScheme(),
 		Config:                      cmConfig,
 		ReconcilerCountPerNamespace: map[string]int{},
-	}).SetupWithManager(mgr, cmConfig.Controllers.Shoot); err != nil {
+	}).SetupWithManager(ctx, mgr, cmConfig.Controllers.Shoot); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Shoot")
 		os.Exit(1)
 	}

--- a/webhooks/configmap_validating_handler.go
+++ b/webhooks/configmap_validating_handler.go
@@ -51,7 +51,7 @@ func (h *ConfigmapValidator) validatingKubeconfigConfigMapFn(ctx context.Context
 
 	userInfo := admissionReq.UserInfo
 
-	// Validate that user has the permission to "manage" configmaps.
+	// Validate that user has the permission to "manage" configMaps.
 	// Usually we only want to have the gardenlogin-controller-manager to have this permission and no one else, so that no one fiddles around with the kubeconfigs
 	if allowed, err := h.canManageConfigmapsAccessReview(ctx, userInfo, c.Namespace, c.Name); err != nil {
 		return false, err.Error(), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the resource quota for count/configmaps is increased or configMap quota was freed a reconciliation is requested for all shoots in the namespace that do not already have a corresponding <shootname>.kubeconfig configMap.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
