### PR TITLE
Use manifest applier

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -17,7 +17,6 @@ else
 fi
 
 ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.20"}
-KUBECTL_VERSION=${KUBECTL_VERSION:-"v1.22.1"}
 KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.3.0"}
 OS=${OS:-"linux"}
 ARCH=${ARCH:-"amd64"}
@@ -26,11 +25,6 @@ bin_dir="${MAIN_REPO_DIR}/bin"
 mkdir -p "${bin_dir}"
 
 pushd "${bin_dir}"
-
-echo "> Get kubectl"
-wget -qO kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${OS}/${ARCH}/kubectl"
-chmod +x kubectl
-export PATH="${bin_dir}/kubectl:$PATH"
 
 echo "> Get kustomize"
 wget -qO kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"

--- a/.landscaper/container/Dockerfile
+++ b/.landscaper/container/Dockerfile
@@ -4,13 +4,9 @@
 
 # Get the required binaries
 FROM golang:1.16.8 as binaries
-ARG kubectl_version=v1.22.1
 ARG kustomize_version=v4.3.0
 
 WORKDIR /workspace
-# Get kubectl
-RUN wget -qO kubectl https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl && \
-    chmod +x kubectl
 # Get kustomize
 RUN wget -qO kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${kustomize_version}/kustomize_${kustomize_version}_linux_amd64.tar.gz && \
     tar -zxf kustomize.tar.gz && \
@@ -40,7 +36,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o container-deployer cmd/
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/container-deployer .
-COPY --from=binaries /workspace/kubectl /usr/bin/kubectl
 COPY --from=binaries /workspace/kustomize /usr/bin/kustomize
 
 # nonroot user https://github.com/GoogleContainerTools/distroless/blob/18b2d2c5ebfa58fe3e0e4ee3ffe0e2651ec0f7f6/base/base.bzl#L8

--- a/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
@@ -62,11 +62,11 @@ func (o *operation) Reconcile(ctx context.Context) error {
 
 	if !o.imports.MultiClusterDeploymentScenario {
 		// single cluster deployment
-		if err := buildAndApplyOverlay(ctx, o.contents.SingleClusterPath, o.singleCluster); err != nil {
+		if err := o.singleCluster.buildAndApplyOverlay(ctx, o.contents.SingleClusterPath); err != nil {
 			return fmt.Errorf("failed to apply overlay for single cluster deployment: %w", err)
 		}
 	} else {
-		if err := buildAndApplyOverlay(ctx, o.contents.VirtualGardenOverlayPath, o.multiCluster.applicationCluster); err != nil {
+		if err := o.multiCluster.applicationCluster.buildAndApplyOverlay(ctx, o.contents.VirtualGardenOverlayPath); err != nil {
 			return fmt.Errorf("failed to applyoverlay for application cluster: %w", err)
 		}
 
@@ -74,7 +74,7 @@ func (o *operation) Reconcile(ctx context.Context) error {
 			return err
 		}
 
-		if err := buildAndApplyOverlay(ctx, o.contents.RuntimeOverlayPath, o.multiCluster.runtimeCluster); err != nil {
+		if err := o.multiCluster.runtimeCluster.buildAndApplyOverlay(ctx, o.contents.RuntimeOverlayPath); err != nil {
 			return fmt.Errorf("failed to apply overlay for runtime cluster: %w", err)
 		}
 	}
@@ -83,7 +83,7 @@ func (o *operation) Reconcile(ctx context.Context) error {
 }
 
 // buildAndApplyOverlay builds the given overlay using kustomize and applies the manifests to the given cluster
-func buildAndApplyOverlay(ctx context.Context, overlayPath string, cluster *cluster) error {
+func (cluster *cluster) buildAndApplyOverlay(ctx context.Context, overlayPath string) error {
 	out, err := exec.Command("kustomize", "build", overlayPath).Output()
 	if err != nil {
 		return fmt.Errorf("failed to run kustomization: %w", err)

--- a/.landscaper/container/pkg/gardenlogin/operation_reconcile_delete_test.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_reconcile_delete_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Operation Reconcile", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tmpDir)
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 
 		Expect(op.Delete(ctx)).To(Succeed())
 	})

--- a/.landscaper/container/pkg/gardenlogin/operation_test.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_test.go
@@ -6,8 +6,6 @@
 package gardenlogin
 
 import (
-	"io/ioutil"
-
 	"github.com/gardener/gardenlogin-controller-manager/.landscaper/container/internal/fake"
 	"github.com/gardener/gardenlogin-controller-manager/.landscaper/container/pkg/api"
 	"github.com/gardener/gardenlogin-controller-manager/.landscaper/container/pkg/test"
@@ -78,9 +76,6 @@ var _ = Describe("Operation", func() {
 			Expect(op.multiCluster.applicationCluster.client).To(Equal(applicationClient))
 			Expect(op.multiCluster.runtimeCluster.client).To(Equal(runtimeClient))
 
-			Expect(ioutil.ReadFile(op.multiCluster.runtimeCluster.kubeconfig)).To(Equal([]byte(runtimeKubeconfig)))
-			Expect(ioutil.ReadFile(op.multiCluster.applicationCluster.kubeconfig)).To(Equal([]byte(applicationKubeconfig)))
-
 			Expect(op.singleCluster).To(BeNil())
 			Expect(op.log).To(Equal(log))
 			Expect(op.clock).To(Equal(f.Clock()))
@@ -114,7 +109,6 @@ var _ = Describe("Operation", func() {
 			Expect(op.singleCluster.client).To(Equal(client))
 			Expect(op.singleCluster.kubernetes).To(Equal(kubeClient))
 
-			Expect(ioutil.ReadFile(op.singleCluster.kubeconfig)).To(Equal([]byte(kubeconfig)))
 			Expect(op.log).To(Equal(log))
 			Expect(op.clock).To(Equal(f.Clock()))
 			Expect(op.imports).To(Equal(imports))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR get's rid of the `kubectl` dependency and instead uses gardeners manifest applier

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
