### PR TITLE
[hotfix-v0.1] Fix resource name

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,7 +9,7 @@ gardenlogin-controller-manager:
         inject_effective_version: true
       publish:
         dockerimages:
-          gardenlogin:
+          gardenlogin-controller-manager:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/gardenlogin-controller-manager'
           gardenlogin-container-deployer:
@@ -45,5 +45,5 @@ gardenlogin-controller-manager:
         component_descriptor: ~
         publish:
           dockerimages:
-            gardenlogin:
+            gardenlogin-controller-manager:
               tag_as_latest: true


### PR DESCRIPTION
(cherry picked from commit 700725b9321efbc590cc1eeaba3462cc2e396740)

**What this PR does / why we need it**:
Fixed resource name to match https://github.com/gardener/gardenlogin-controller-manager/blob/master/.landscaper/container/pkg/api/images.go#L26

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed the resource name in the component descriptor for the `gardenlogin-controller-manager` image, as it is assumed to be `gardenlogin-controller-manager` and not `gardenlogin`
```

