### PR TITLE
[master] Fix issue where metrics could not be scraped

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,9 +18,9 @@ gardenlogin-controller-manager:
             dir: .landscaper/container
     steps:
       check:
-        image: 'golang:1.16.8'
+        image: 'golang:1.17.3'
       test:
-        image: 'golang:1.16.8'
+        image: 'golang:1.17.3'
   jobs:
     head-update:
       traits:

--- a/.landscaper/blueprint/config/manager/manager.yaml
+++ b/.landscaper/blueprint/config/manager/manager.yaml
@@ -63,6 +63,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/gardenlogin-controller-manager
             name: manager-config
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
         - configMap:

--- a/.landscaper/blueprint/config/overlay/multi-cluster/runtime/kustomization.yaml
+++ b/.landscaper/blueprint/config/overlay/multi-cluster/runtime/kustomization.yaml
@@ -7,9 +7,12 @@ namespace: gardenlogin-system # namespace should not start with garden- to preve
 
 namePrefix: gardenlogin- # must match with namePrefix defined in ../../default/kustomization.yaml
 
-commonLabels:
-  component: gardenlogin-manager
+labels:
+  - includeSelectors: true
+    pairs:
+      component: gardenlogin-manager
 
 resources:
 - manager
+- rbac # contains only multi-cluster specific kustomization for the runtime cluster
 - ../../../rbac-rt

--- a/.landscaper/blueprint/config/overlay/multi-cluster/runtime/rbac/kustomization.yaml
+++ b/.landscaper/blueprint/config/overlay/multi-cluster/runtime/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+resources:
+- service_account.yaml

--- a/.landscaper/blueprint/config/overlay/multi-cluster/runtime/rbac/service_account.yaml
+++ b/.landscaper/blueprint/config/overlay/multi-cluster/runtime/rbac/service_account.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system

--- a/.landscaper/blueprint/config/overlay/multi-cluster/virtual-garden/kustomization.yaml
+++ b/.landscaper/blueprint/config/overlay/multi-cluster/virtual-garden/kustomization.yaml
@@ -7,8 +7,10 @@ namespace: gardenlogin-system # namespace should not start with garden- to preve
 
 namePrefix: gardenlogin- # must match with namePrefix defined in ../../default/kustomization.yaml
 
-commonLabels:
-  component: gardenlogin-manager
+labels:
+  - includeSelectors: true
+    pairs:
+      component: gardenlogin-manager
 
 resources:
 - ../../../rbac

--- a/.landscaper/container/Dockerfile
+++ b/.landscaper/container/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Get the required binaries
-FROM golang:1.16.8 as binaries
+FROM golang:1.17.3 as binaries
 ARG kustomize_version=v4.3.0
 
 WORKDIR /workspace
@@ -13,7 +13,7 @@ RUN wget -qO kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/relea
     chmod +x kustomize
 
 # Build the container-deployer binary
-FROM golang:1.16.8 as builder
+FROM golang:1.17.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/.landscaper/container/Makefile
+++ b/.landscaper/container/Makefile
@@ -48,15 +48,15 @@ fmt: ## Run go fmt against code.
 lint: $(GOPATH)/bin/golangci-lint ## Run golangci-lint against code.
 	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"
 
-test: fmt lint envtest-use ## Run tests.
-	go test ./... -coverprofile cover.out
+test: fmt lint ## Run tests.
+	@./hack/test-integration.sh
 
 ##@ Build
 
 build: fmt lint ## Build container-deployer binary.
 	go build -o bin/container-deployer main.go
 
-run: generate fmt lint ## Run a controller from your host.
+run: fmt lint ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the container-deployer.
@@ -78,10 +78,7 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-envtest-use: envtest ## Run envtest-setup use.
-	$(ENVTEST) use 1.21
-
-# go-install-tool will 'go install' any package $2 and install it to $1.
+# go-install-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-install-tool
 @[ -f $(1) ] || { \

--- a/.landscaper/container/go.mod
+++ b/.landscaper/container/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardenlogin-controller-manager/.landscaper/container
 
-go 1.16
+go 1.17
 
 require (
 	github.com/gardener/component-cli v0.29.0
@@ -22,6 +22,120 @@ require (
 	sigs.k8s.io/controller-runtime v0.9.1
 	sigs.k8s.io/kind v0.7.0
 	sigs.k8s.io/yaml v1.2.0
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/drone/envsubst v1.0.2 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gardener/etcd-druid v0.5.0 // indirect
+	github.com/gardener/external-dns-management v0.7.18 // indirect
+	github.com/gardener/gardener-resource-manager v0.25.0 // indirect
+	github.com/gardener/gardener-resource-manager/api v0.0.0-00010101000000-000000000000 // indirect
+	github.com/gardener/hvpa-controller v0.3.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/mandelsoft/filepath v0.0.0-20200909114706-3df73d378d55 // indirect
+	github.com/mandelsoft/vfs v0.0.0-20210530103237-5249dc39ce91 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mholt/archiver v3.1.1+incompatible // indirect
+	github.com/mitchellh/copystructure v1.1.1 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/robfig/cron v1.2.0 // indirect
+	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/ulikunitz/xz v0.5.6 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/grpc v1.38.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	istio.io/api v0.0.0-20210520012029-891c0c12abfd // indirect
+	istio.io/client-go v1.10.1 // indirect
+	istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f // indirect
+	k8s.io/apiextensions-apiserver v0.21.2 // indirect
+	k8s.io/apiserver v0.21.2 // indirect
+	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e // indirect
+	k8s.io/helm v2.16.1+incompatible // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-aggregator v0.21.2 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/metrics v0.21.2 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 )
 
 replace (

--- a/.landscaper/container/hack/test-integration.sh
+++ b/.landscaper/container/hack/test-integration.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+
+# For the check step concourse will set the following environment variables:
+# SOURCE_PATH - path to component repository root directory.
+if [[ -z "${SOURCE_PATH}" ]]; then
+  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/../../../")"
+else
+  export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
+fi
+
+KUSTOMIZE_VERSION=${KUSTOMIZE_VERSION:-"v4.3.0"}
+GO_TEST_ADDITIONAL_FLAGS=${GO_TEST_ADDITIONAL_FLAGS:-""}
+OS=${OS:-$(go env GOOS)}
+ARCH=${ARCH:-$(go env GOARCH)}
+
+bin_dir="${SOURCE_PATH}/.landscaper/container/bin"
+mkdir -p "${bin_dir}"
+
+pushd "${bin_dir}"
+
+echo "> Get kustomize"
+wget -qO kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${OS}_${ARCH}.tar.gz"
+tar -zxf kustomize.tar.gz && rm kustomize.tar.gz
+chmod +x kustomize
+
+export PATH="${bin_dir}:$PATH"
+
+popd
+
+source "${SOURCE_PATH}/hack/test-common.sh"
+
+run_test gardenlogin-container-deployer "${SOURCE_PATH}/.landscaper/container" "${GO_TEST_ADDITIONAL_FLAGS}"

--- a/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
+++ b/.landscaper/container/pkg/gardenlogin/operation_reconcile.go
@@ -127,9 +127,14 @@ func (o *operation) Reconcile(ctx context.Context) error {
 
 // buildAndApplyOverlay builds the given overlay using kustomize and applies the manifests to the given cluster
 func (cluster *cluster) buildAndApplyOverlay(ctx context.Context, overlayPath string) error {
-	out, err := exec.Command("kustomize", "build", overlayPath).Output()
+	cmd := exec.Command("kustomize", "build", overlayPath)
+
+	var errBuff bytes.Buffer
+	cmd.Stderr = &errBuff
+
+	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("failed to run kustomization: %w", err)
+		return fmt.Errorf("failed to run kustomization: %s, %w", errBuff.String(), err)
 	}
 
 	applier := kubernetes.NewApplier(cluster.client, cluster.client.RESTMapper())

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.16.8 as builder
+FROM golang:1.17.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ fmt: ## Run go fmt against code.
 lint: $(GOPATH)/bin/golangci-lint ## Run golangci-lint against code.
 	golangci-lint run ./... -E golint,whitespace,wsl --skip-files "zz_generated.*"
 
-test: manifests generate fmt lint envtest-use ## Run tests.
-	go test ./... -coverprofile cover.out
+test: manifests generate fmt lint ## Run tests.
+	@./hack/test-integration.sh
 
 ##@ Build
 
@@ -111,9 +111,6 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
-
-envtest-use: envtest ## Run envtest-setup use.
-	$(ENVTEST) use 1.21
 
 # go-install-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,13 @@
 module github.com/gardener/gardenlogin-controller-manager
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/frankban/quicktest v1.13.0 // indirect
 	github.com/gardener/gardener v1.31.0
 	github.com/go-logr/logr v0.4.0
-	github.com/golang/snappy v0.0.3 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
-	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/ulikunitz/xz v0.5.10 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
@@ -21,6 +15,115 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	sigs.k8s.io/controller-runtime v0.9.1
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/frankban/quicktest v1.13.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gardener/etcd-druid v0.5.0 // indirect
+	github.com/gardener/external-dns-management v0.7.18 // indirect
+	github.com/gardener/gardener-resource-manager v0.25.0 // indirect
+	github.com/gardener/gardener-resource-manager/api v0.0.0-00010101000000-000000000000 // indirect
+	github.com/gardener/hvpa-controller v0.3.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.3 // indirect
+	github.com/go-openapi/spec v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/mailru/easyjson v0.7.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mholt/archiver v3.1.1+incompatible // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/nwaples/rardecode v1.1.0 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/robfig/cron v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/spf13/cobra v1.1.3 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect
+	google.golang.org/grpc v1.35.0 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	istio.io/api v0.0.0-20210520012029-891c0c12abfd // indirect
+	istio.io/client-go v1.10.1 // indirect
+	istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f // indirect
+	k8s.io/apiextensions-apiserver v0.21.2 // indirect
+	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e // indirect
+	k8s.io/component-base v0.21.2 // indirect
+	k8s.io/helm v2.16.1+incompatible // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-aggregator v0.21.2 // indirect
+	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 // indirect
+	k8s.io/metrics v0.21.2 // indirect
+	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.19 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
 replace (

--- a/hack/test-common.sh
+++ b/hack/test-common.sh
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.20"}
+
+function run_test {
+  local component=$1
+  local target_dir=$2
+  local go_test_additional_flags=$3
+  echo "> Test $component"
+
+  pushd "${target_dir}" || exit
+
+  make envtest
+
+  # --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
+  KUBEBUILDER_ASSETS=$(bin/setup-envtest use --use-env -p path "${ENVTEST_K8S_VERSION}")
+  export KUBEBUILDER_ASSETS
+
+  echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
+
+  GO111MODULE=on go test ./... -coverprofile cover.out "${go_test_additional_flags}"
+
+  popd || exit
+}

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -9,14 +9,14 @@ set -o pipefail
 
 # For the check step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
-
 if [[ -z "${SOURCE_PATH}" ]]; then
   export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
 else
   export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
 fi
 
-export GO_TEST_ADDITIONAL_FLAGS="-race"
+GO_TEST_ADDITIONAL_FLAGS=${GO_TEST_ADDITIONAL_FLAGS:-""}
 
-"${SOURCE_PATH}"/hack/test-integration.sh
-"${SOURCE_PATH}"/.landscaper/container/hack/test-integration.sh
+source "${SOURCE_PATH}/hack/test-common.sh"
+
+run_test gardenlogin-controller-manager "${SOURCE_PATH}" "${GO_TEST_ADDITIONAL_FLAGS}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the metrics cannot be fetched and the `kube-rbac-proxy` container logs the following error message:

`
E1111 16:46:00.919070       1 proxy.go:73] Unable to authenticate the request due to an error: tokenreviews.authentication.k8s.io is forbidden: User "system:serviceaccount:gardenlogin-system:default" cannot create resource "tokenreviews" in API group "authentication.k8s.io" at the cluster scope
`

Here the `default` service account is used instead of the `gardenlogin-controller-manager`.

This PR (check individual commits):
- fixes the above mentioned issue
- bumps goang to 1.17.3
- better error logs in case `kustomize` fails with an error
- `hack/test-integration.sh` is called when running `make test` reducing duplicate code

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator

```
