### PR TITLE
Do not delete configmap when deletion timestamp is set

### DIFF
--- a/controllers/shoot_controller.go
+++ b/controllers/shoot_controller.go
@@ -424,16 +424,6 @@ func (r *ShootReconciler) handleRequest(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	if shootState.DeletionTimestamp != nil {
-		// shootstate is in deletion - cleanup kubeconfig configMap
-		return ctrl.Result{}, client.IgnoreNotFound(r.Client.Delete(ctx, kubeconfigConfigMap))
-	}
-
-	if shoot.DeletionTimestamp != nil {
-		// shoot is in deletion - cleanup kubeconfig configMap
-		return ctrl.Result{}, client.IgnoreNotFound(r.Client.Delete(ctx, kubeconfigConfigMap))
-	}
-
 	if len(shoot.Status.AdvertisedAddresses) == 0 {
 		// we have a watch on the shoot and changes to the advertised addresses should trigger a new reconcile anyhow so there is no need to requeue it immediately
 		return ctrl.Result{RequeueAfter: 60 * time.Minute}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The `gardenlogin` kubeconfig `ConfigMap` should not be deleted when just the deletion timestamp is set on the `Shoot` or `ShootState` resource.
E.g. it can happen that the deletion of the shoot fails / is stuck and the `Shoot` cluster needs to be inspected, therefore the `Configmap` should not be deleted too early.

In the following cases the `gardenlogin` kubeconfig `ConfigMap` will be deleted:
- There is an ownerRef on the `ConfigMap` for the corresponding `Shoot`. Once the shoot is removed, also the `ConfigMap` get's deleted
- When the controller tries to fetch the `Shoot` or `ShootState` and it fails with a not found error, the `ConfigMap` will be deleted

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the `gardenlogin` kubeconfig `ConfigMap` was deleted too early
```
