### PR TITLE
mark 3rd-party image as `external`, fixate version

### DIFF
--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -11,7 +11,8 @@ input:
 ---
 type: ociImage
 name: kube-rbac-proxy
-relation: local
+version: v0.8.0
+relation: external
 access:
   type: ociRegistry
   imageReference: quay.io/brancz/kube-rbac-proxy:v0.8.0


### PR DESCRIPTION
Resources declared in a `Component-Descriptor` ought declare those
(and only those) resources as `local` that are built from sources of the
declaring `Component`. Other resources ought to be declared as
`external`.

