### PR TITLE
Fix reading CA certificate from ShootState

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,4 +11,4 @@ linters:
     - goimports
 linters-settings:
   goimports:
-    local-prefixes: github.com/gardener/gardenctl-v2
+    local-prefixes: github.com/gardener/gardenlogin-controller-manager

--- a/controllers/shoot_controller.go
+++ b/controllers/shoot_controller.go
@@ -568,7 +568,12 @@ func clusterCaCert(shootState *gardencorev1alpha1.ShootState) ([]byte, error) {
 		return nil, errors.New("failed to unmarshal certificate authority from raw data")
 	}
 
-	return data[secrets.DataKeyCertificateCA], nil
+	key := secrets.DataKeyCertificateCA
+	if ca.Type == "certificate" {
+		key = "certificate"
+	}
+
+	return data[key], nil
 }
 
 // kubeconfigRequest is a struct which holds information about a Kubeconfig to be generated.

--- a/controllers/shoot_controller_test.go
+++ b/controllers/shoot_controller_test.go
@@ -9,6 +9,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gardener/gardener/pkg/utils"
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
@@ -237,12 +238,7 @@ var _ = Describe("ShootController", func() {
 			}
 
 			ca = generateCaCert()
-			caInfoData := secrets.CertificateInfoData{
-				Certificate: ca.CertificatePEM,
-			}
-
-			caRaw, err := caInfoData.Marshal()
-			Expect(err).ToNot(HaveOccurred())
+			caRaw := []byte(`{"ca.crt":"` + utils.EncodeBase64(ca.CertificatePEM) + `"}`)
 
 			shootState = &gardencorev1alpha1.ShootState{
 				ObjectMeta: metav1.ObjectMeta{
@@ -253,7 +249,7 @@ var _ = Describe("ShootController", func() {
 					Gardener: []gardencorev1alpha1.GardenerResourceData{
 						{
 							Name: corev1beta1constants.SecretNameCACluster,
-							Type: "certificate",
+							Type: "secret",
 							Data: runtime.RawExtension{Raw: caRaw},
 						},
 					},

--- a/controllers/shoot_controller_test.go
+++ b/controllers/shoot_controller_test.go
@@ -9,12 +9,12 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardener/pkg/utils"
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test/matchers"

--- a/go.sum
+++ b/go.sum
@@ -1730,7 +1730,6 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-runtime v0.7.1/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
-sigs.k8s.io/controller-runtime v0.11.0 h1:DqO+c8mywcZLFJWILq4iktoECTyn30Bkj0CwgqMpZWQ=
 sigs.k8s.io/controller-runtime v0.11.0/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
 sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
 sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=

--- a/go.sum
+++ b/go.sum
@@ -1730,6 +1730,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-runtime v0.7.1/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
+sigs.k8s.io/controller-runtime v0.11.0 h1:DqO+c8mywcZLFJWILq4iktoECTyn30Bkj0CwgqMpZWQ=
 sigs.k8s.io/controller-runtime v0.11.0/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
 sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
 sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=


### PR DESCRIPTION
**What this PR does / why we need it**:

/kind regression

We need to support the old and new way of reading the CA certificate.


**Which issue(s) this PR fixes**:
Fixes #23

After https://github.com/gardener/gardener/pull/5503, the CA certificate of a shoot cluster is persisted differently in the ShootState.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
